### PR TITLE
Replace undefined with FIXME to find gaps quickly

### DIFF
--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -124,6 +124,7 @@ function generateSpecFile(npm_module, dependencies, release, template) {
     spec_file = replaceAttribute(spec_file, '\\$BUILD', '%nodejs_symlink_deps --build');
     spec_file = replaceAttribute(spec_file, '\\$PROVIDES', '%{?nodejs_find_provides_and_requires}');
   }
+	spec_file = replaceAttribute(spec_file, 'undefined', 'FIXME');
 	return spec_file;
 }
 


### PR DESCRIPTION
vim and others will highlight the text "FIXME" making it easier to
find mistakes in the resulting spec file.
