### PR TITLE
Copy docs into build dir when in bundle mode

### DIFF
--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -98,6 +98,8 @@ function copyFiles(npm_module){
   if (npm_module.bundle)
     result += 'cd node_modules/' + npm_module.name + '\n';
   result += ('cp -pfr ' + filesToCopy(npm_module) + ' %{buildroot}%{nodejs_sitelib}/%{npm_name}');
+  if (npm_module.bundle)
+    result += ('\ncp -pf ' + npm_module.doc_files.join(' ') + ' ../../');
   return result;
 }
 


### PR DESCRIPTION
For %doc to work and copy files into the docdir, the source files must
be in the main build dir rather than the node_modules/%{name} subdir.
