### PR TITLE
Disable installation of optional deps in bundle builds

### DIFF
--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -133,7 +133,7 @@ function generateSpecFile(npm_module, dependencies, release, template) {
 }
 
 function npmInstallCache() {
-  return 'npm install --cache-min Infinity --cache . %{npm_name}@%{version}';
+  return 'npm install --cache-min Infinity --cache . --no-optional --global-style true %{npm_name}@%{version}';
 }
 
 function sourcesToCache(deps) {


### PR DESCRIPTION
Plus enable global-style to deploy dependencies in node_modules/ beneath
the dependent module, instead of the de-dupe behaviour now default in
newer npm versions.