### PR TITLE
remove fedora 19 conditional

### DIFF
--- a/default.n2r
+++ b/default.n2r
@@ -15,12 +15,7 @@ URL: $PROJECTURL
 $SOURCES
 BuildRequires: nodejs-packaging
 BuildArch:  noarch
-
-%if 0%{?fedora} >= 19
 ExclusiveArch: %{nodejs_arches} noarch
-%else
-ExclusiveArch: %{ix86} x86_64 %{arm} noarch
-%endif
 
 $PROVIDES
 


### PR DESCRIPTION
%{nodejs_arches} macro is in all active Fedora releases and in EPEL 6 & 7. I think the conditional can be dropped by now.