### PR TITLE
Specify package version when building cache

### DIFF
--- a/bin/generate_npm_tarball.sh
+++ b/bin/generate_npm_tarball.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $# -ne 2 ]; then
-  echo "usage: $0 PACKAGE OUTPUT.TGZ"
+  echo "usage: $0 PACKAGE[@VERSION] OUTPUT.TGZ"
   exit 1
 fi
 package=$1

--- a/bin/npm2rpm.js
+++ b/bin/npm2rpm.js
@@ -126,6 +126,6 @@ function downloadDependencies(dependencies) {
 
 function createNpmCacheTar(npm_module) {
   var filename = npm_module.name + '-' + npm_module.version + '-registry.npmjs.org.tgz'
-  execSync([path.join(__dirname, '/generate_npm_tarball.sh'), npm_module.name,
+  execSync([path.join(__dirname, '/generate_npm_tarball.sh'), npm_module.name + '@' + npm_module.version,
            ' ', path.join('npm2rpm/SOURCES/', filename)].join(' '), {stdio:[0,1,2]});
 }


### PR DESCRIPTION
When building an older package than the latest, ensures the correct
cached data is requested.