### PR TITLE
Various fixes

### DIFF
--- a/default.n2r
+++ b/default.n2r
@@ -19,6 +19,7 @@ ExclusiveArch: %{nodejs_arches} noarch
 
 $PROVIDES
 
+%define npm_cache_dir /tmp/npm_cache_%{name}-%{version}-%{release}
 %description
 %{summary}
 
@@ -36,6 +37,9 @@ $BINSNIPPET
 
 %nodejs_symlink_deps
 
+%clean
+rm -rf %{buildroot} %{npm_cache_dir}
+
 %if 0%{?enable_tests}
 %check
 %{nodejs_symlink_deps} --check
@@ -49,3 +53,5 @@ $LICENSEFILE
 $DOCFILES
 
 %changelog
+* $DATE author@example.com <Author Name> - $VERSION-$RELEASE
+- First release 

--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -67,7 +67,7 @@ function listBinaryFiles(binaries) {
   } else {
     var binary_files = '';
     for(var binary in binaries) {
-      binary_files += getBasename(binaries[binary]);
+      binary_files += '%{_bindir}/' + getBasename(binaries[binary]);
       binary_files += '\n';
     }
     return binary_files;

--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var datejs=require('datejs');
 var helpers = require('../lib/npm_helpers.js');
 module.exports = generateSpecFile;
 
@@ -99,7 +100,7 @@ function copyFiles(npm_module){
     result += 'cd node_modules/' + npm_module.name + '\n';
   result += ('cp -pfr ' + filesToCopy(npm_module) + ' %{buildroot}%{nodejs_sitelib}/%{npm_name}');
   if (npm_module.bundle)
-    result += ('\ncp -pf ' + npm_module.doc_files.join(' ') + ' ../../');
+    result += ('\ncp -pf ' + npm_module.doc_files.join(' ') + ' ' + npm_module.license_file + ' ../../');
   return result;
 }
 
@@ -117,6 +118,7 @@ function generateSpecFile(npm_module, dependencies, release, template) {
 	spec_file = replaceAttribute(spec_file, '\\$FILESBINSNIPPET', listBinaryFiles(npm_module.binaries));
 	spec_file = replaceAttribute(spec_file, '\\$COPYFILES', copyFiles(npm_module));
 	spec_file = replaceAttribute(spec_file, '\\$DOCFILES', listDocFiles(npm_module.doc_files));
+    	spec_file = replaceAttribute(spec_file, '\\$DATE', Date.today().toString("ddd MMM d yyyy"));
   if (npm_module.bundle) {
     spec_file = replaceAttribute(spec_file, '\\$PROVIDES', dependenciesToProvides(dependencies));
     spec_file = replaceAttribute(spec_file, '\\$SOURCES', dependenciesToSources(dependencies));
@@ -137,10 +139,10 @@ function npmInstallCache() {
 }
 
 function sourcesToCache(deps) {
-  return 'mkdir npm_cache\n\
+  return 'mkdir -p %{npm_cache_dir}\n\
 for tgz in %{sources}; do\n\
-  echo $tgz | grep -q registry.npmjs.org || npm cache add --cache ./npm_cache $tgz\n\
+  echo $tgz | grep -q registry.npmjs.org || npm cache add --cache ./%{npm_cache_dir} $tgz\n\
 done\n\
 \n\
-%setup -T -q -a ' + deps.length + ' -D -n npm_cache';
+%setup -T -q -a ' + deps.length + ' -D -n %{npm_cache_dir}';
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tmp": "~0.0.28",
     "tar": "~2.2.1",
     "npm-remote-ls": "~1.3.2",
-    "datejs": ">=1.0.0",
+    "datejs": "*",
     "async": "~1.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "tmp": "~0.0.28",
     "tar": "~2.2.1",
     "npm-remote-ls": "~1.3.2",
+    "datejs": ">=1.0.0",
     "async": "~1.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- Auto generate first %changelog entry
- Copy LICENSE file (defined in lib/npm_module.js) to %{buildroot} so the %doc macro will work
- Add %clean section to spec template