### PR TITLE
Use https://registry.npmjs.org

### DIFF
--- a/lib/npm_helpers.js
+++ b/lib/npm_helpers.js
@@ -5,7 +5,7 @@ var request = require('request');
 var tmp = require('tmp');
 
 module.exports.npmUrl = (name, version) => {
-  return 'http://registry.npmjs.org/' + name + '/-/' + name + '-' + version + '.tgz';
+  return 'https://registry.npmjs.org/' + name + '/-/' + name + '-' + version + '.tgz';
 }
 
 module.exports.downloadFromNPM = (name, version) => {


### PR DESCRIPTION
Since it redirects anyway this saves some overhead.