### PR TITLE
Fix handling of pinned dependencies

### DIFF
--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -75,7 +75,7 @@ function dependenciesToRequires(deps) {
         } else if (constraint.startsWith('>') || constraint.startsWith('<')) {
           dependencies.push('npm(' + dep + ') ' + constraint);
         } else {
-          dependencies.push('npm(' + dep + ') =' + constraint);
+          dependencies.push('npm(' + dep + ') = ' + constraint);
         }
       });
     }

--- a/test/spec_file_generator_test.js
+++ b/test/spec_file_generator_test.js
@@ -5,7 +5,7 @@ describe('dependenciesToRequires', () => {
   var d2r = specFileGenerator.dependenciesToRequires;
   it('handles a single version number', () => {
     var deps = {'foo': '1.2.3'};
-    assert.deepEqual(d2r(deps), ['npm(foo) =1.2.3']);
+    assert.deepEqual(d2r(deps), ['npm(foo) = 1.2.3']);
   });
 
   it('handles comparators', () => {
@@ -17,7 +17,7 @@ describe('dependenciesToRequires', () => {
 
     assert.deepEqual(d2r(lt),  ['npm(foo) <1.2.3']);
     assert.deepEqual(d2r(lte), ['npm(foo) <=1.2.3']);
-    assert.deepEqual(d2r(eq),  ['npm(foo) =1.2.3']);
+    assert.deepEqual(d2r(eq),  ['npm(foo) = 1.2.3']);
     assert.deepEqual(d2r(gt),  ['npm(foo) >1.2.3']);
     assert.deepEqual(d2r(gte), ['npm(foo) >=1.2.3']);
   });


### PR DESCRIPTION
For pinned dependencies, rpmbuild expects the syntax "Requires:
$package = 2.11.0", not "Requires: $package =2.11.0".  This change
fixes issue #53.