### PR TITLE
Fix syntax for dependencies with operators

### DIFF
--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -70,10 +70,11 @@ function dependenciesToRequires(deps) {
       //  - just a version number, e.g. 1.2.3, meaning the requirement is equal to that
       //  - a constraint (<,>,>=,<=) and a version number, which can be used as-is
       versionDNF[0].forEach((constraint) => {
+        var m;
         if (constraint === '*') {
           dependencies.push('npm(' + dep + ')');
-        } else if (constraint.startsWith('>') || constraint.startsWith('<')) {
-          dependencies.push('npm(' + dep + ') ' + constraint);
+        } else if ((m = constraint.match(/^([<>]=?)(.*?)$/)) !== null) {
+          dependencies.push('npm(' + dep + ') ' + m[1] + ' ' + m[2]);
         } else {
           dependencies.push('npm(' + dep + ') = ' + constraint);
         }

--- a/test/spec_file_generator_test.js
+++ b/test/spec_file_generator_test.js
@@ -15,25 +15,25 @@ describe('dependenciesToRequires', () => {
     var gt  = {'foo': '> 1.2.3'};
     var gte = {'foo': '>= 1.2.3'};
 
-    assert.deepEqual(d2r(lt),  ['npm(foo) <1.2.3']);
-    assert.deepEqual(d2r(lte), ['npm(foo) <=1.2.3']);
+    assert.deepEqual(d2r(lt),  ['npm(foo) < 1.2.3']);
+    assert.deepEqual(d2r(lte), ['npm(foo) <= 1.2.3']);
     assert.deepEqual(d2r(eq),  ['npm(foo) = 1.2.3']);
-    assert.deepEqual(d2r(gt),  ['npm(foo) >1.2.3']);
-    assert.deepEqual(d2r(gte), ['npm(foo) >=1.2.3']);
+    assert.deepEqual(d2r(gt),  ['npm(foo) > 1.2.3']);
+    assert.deepEqual(d2r(gte), ['npm(foo) >= 1.2.3']);
   });
 
   it('handles basic ranges', () => {
     var deps = {'foo': '>= 1.2.3 <4.5.6'};
-    assert.deepEqual(d2r(deps), ['npm(foo) >=1.2.3', 'npm(foo) <4.5.6']);
+    assert.deepEqual(d2r(deps), ['npm(foo) >= 1.2.3', 'npm(foo) < 4.5.6']);
   });
 
   it('handles hyphen ranges', () => {
     var depsFull = {'foo': '1.2.3 - 4.5.6'};
     var depsPartialStart = {'foo': '1.2 - 4.5.6'};
     var depsPartialEnd = {'foo': '1.2.3 - 4.5'};
-    assert.deepEqual(d2r(depsFull), ['npm(foo) >=1.2.3', 'npm(foo) <=4.5.6']);
-    assert.deepEqual(d2r(depsPartialStart), ['npm(foo) >=1.2.0', 'npm(foo) <=4.5.6']);
-    assert.deepEqual(d2r(depsPartialEnd), ['npm(foo) >=1.2.3', 'npm(foo) <4.6.0']);
+    assert.deepEqual(d2r(depsFull), ['npm(foo) >= 1.2.3', 'npm(foo) <= 4.5.6']);
+    assert.deepEqual(d2r(depsPartialStart), ['npm(foo) >= 1.2.0', 'npm(foo) <= 4.5.6']);
+    assert.deepEqual(d2r(depsPartialEnd), ['npm(foo) >= 1.2.3', 'npm(foo) < 4.6.0']);
   });
 
   it('handles X-ranges', () => {
@@ -46,13 +46,13 @@ describe('dependenciesToRequires', () => {
     var deps2X3 = {'foo': '1'};
     var deps3X1 = {'foo': '*'};
     var deps3X2 = {'foo': ''};
-    assert.deepEqual(d2r(deps1X1), ['npm(foo) >=1.2.0', 'npm(foo) <1.3.0']);
-    assert.deepEqual(d2r(deps1X2), ['npm(foo) >=1.2.0', 'npm(foo) <1.3.0']);
-    assert.deepEqual(d2r(deps1X3), ['npm(foo) >=1.2.0', 'npm(foo) <1.3.0']);
-    assert.deepEqual(d2r(deps1X4), ['npm(foo) >=1.2.0', 'npm(foo) <1.3.0']);
-    assert.deepEqual(d2r(deps2X1), ['npm(foo) >=1.0.0', 'npm(foo) <2.0.0']);
-    assert.deepEqual(d2r(deps2X2), ['npm(foo) >=1.0.0', 'npm(foo) <2.0.0']);
-    assert.deepEqual(d2r(deps2X3), ['npm(foo) >=1.0.0', 'npm(foo) <2.0.0']);
+    assert.deepEqual(d2r(deps1X1), ['npm(foo) >= 1.2.0', 'npm(foo) < 1.3.0']);
+    assert.deepEqual(d2r(deps1X2), ['npm(foo) >= 1.2.0', 'npm(foo) < 1.3.0']);
+    assert.deepEqual(d2r(deps1X3), ['npm(foo) >= 1.2.0', 'npm(foo) < 1.3.0']);
+    assert.deepEqual(d2r(deps1X4), ['npm(foo) >= 1.2.0', 'npm(foo) < 1.3.0']);
+    assert.deepEqual(d2r(deps2X1), ['npm(foo) >= 1.0.0', 'npm(foo) < 2.0.0']);
+    assert.deepEqual(d2r(deps2X2), ['npm(foo) >= 1.0.0', 'npm(foo) < 2.0.0']);
+    assert.deepEqual(d2r(deps2X3), ['npm(foo) >= 1.0.0', 'npm(foo) < 2.0.0']);
     assert.deepEqual(d2r(deps3X1), ['npm(foo)']);
     assert.deepEqual(d2r(deps3X2), ['npm(foo)']);
   });
@@ -66,13 +66,13 @@ describe('dependenciesToRequires', () => {
     var tildeUnstablePartial2    = {'foo': '~0'};
     var tildePreRelease          = {'foo': '~1.2.3-beta.2'};
 
-    assert.deepEqual(d2r(tildeFullVersion),         ['npm(foo) >=1.2.3', 'npm(foo) <1.3.0']);
-    assert.deepEqual(d2r(tildePartial1),            ['npm(foo) >=1.2.0', 'npm(foo) <1.3.0']);
-    assert.deepEqual(d2r(tildePartial2),            ['npm(foo) >=1.0.0', 'npm(foo) <2.0.0']);
-    assert.deepEqual(d2r(tildeUnstableFullVersion), ['npm(foo) >=0.2.3', 'npm(foo) <0.3.0']);
-    assert.deepEqual(d2r(tildeUnstablePartial1),    ['npm(foo) >=0.2.0', 'npm(foo) <0.3.0']);
-    assert.deepEqual(d2r(tildeUnstablePartial2),    ['npm(foo) >=0.0.0', 'npm(foo) <1.0.0']);
-    assert.deepEqual(d2r(tildePreRelease),          ['npm(foo) >=1.2.3-beta.2', 'npm(foo) <1.3.0']);
+    assert.deepEqual(d2r(tildeFullVersion),         ['npm(foo) >= 1.2.3', 'npm(foo) < 1.3.0']);
+    assert.deepEqual(d2r(tildePartial1),            ['npm(foo) >= 1.2.0', 'npm(foo) < 1.3.0']);
+    assert.deepEqual(d2r(tildePartial2),            ['npm(foo) >= 1.0.0', 'npm(foo) < 2.0.0']);
+    assert.deepEqual(d2r(tildeUnstableFullVersion), ['npm(foo) >= 0.2.3', 'npm(foo) < 0.3.0']);
+    assert.deepEqual(d2r(tildeUnstablePartial1),    ['npm(foo) >= 0.2.0', 'npm(foo) < 0.3.0']);
+    assert.deepEqual(d2r(tildeUnstablePartial2),    ['npm(foo) >= 0.0.0', 'npm(foo) < 1.0.0']);
+    assert.deepEqual(d2r(tildePreRelease),          ['npm(foo) >= 1.2.3-beta.2', 'npm(foo) < 1.3.0']);
   });
 
   it('handles caret ranges', () => {
@@ -88,16 +88,16 @@ describe('dependenciesToRequires', () => {
     var caretPreRelease           = {'foo': '^1.2.3-beta.2'};
     var caretUnstablePreRelease   = {'foo': '^0.0.3-beta.2'};
 
-    assert.deepEqual(d2r(caretFullVersion),          ['npm(foo) >=1.2.3', 'npm(foo) <2.0.0']);
-    assert.deepEqual(d2r(caretPartial1),             ['npm(foo) >=1.2.0', 'npm(foo) <2.0.0']);
-    assert.deepEqual(d2r(caretPartial2),             ['npm(foo) >=1.0.0', 'npm(foo) <2.0.0']);
-    assert.deepEqual(d2r(caretUnstableFullVersion),  ['npm(foo) >=0.2.3', 'npm(foo) <0.3.0']);
-    assert.deepEqual(d2r(caretUnstablePartial1),     ['npm(foo) >=0.2.0', 'npm(foo) <0.3.0']);
-    assert.deepEqual(d2r(caretUnstable2FullVersion), ['npm(foo) >=0.0.3', 'npm(foo) <0.0.4']);
-    assert.deepEqual(d2r(caretUnstable2Partial1),    ['npm(foo) >=0.0.0', 'npm(foo) <0.1.0']);
-    assert.deepEqual(d2r(caretUnstable2Partial2),    ['npm(foo) >=0.0.0', 'npm(foo) <0.1.0']);
-    assert.deepEqual(d2r(caretPreRelease),           ['npm(foo) >=1.2.3-beta.2', 'npm(foo) <2.0.0']);
-    assert.deepEqual(d2r(caretUnstablePreRelease),   ['npm(foo) >=0.0.3-beta.2', 'npm(foo) <0.0.4']);
+    assert.deepEqual(d2r(caretFullVersion),          ['npm(foo) >= 1.2.3', 'npm(foo) < 2.0.0']);
+    assert.deepEqual(d2r(caretPartial1),             ['npm(foo) >= 1.2.0', 'npm(foo) < 2.0.0']);
+    assert.deepEqual(d2r(caretPartial2),             ['npm(foo) >= 1.0.0', 'npm(foo) < 2.0.0']);
+    assert.deepEqual(d2r(caretUnstableFullVersion),  ['npm(foo) >= 0.2.3', 'npm(foo) < 0.3.0']);
+    assert.deepEqual(d2r(caretUnstablePartial1),     ['npm(foo) >= 0.2.0', 'npm(foo) < 0.3.0']);
+    assert.deepEqual(d2r(caretUnstable2FullVersion), ['npm(foo) >= 0.0.3', 'npm(foo) < 0.0.4']);
+    assert.deepEqual(d2r(caretUnstable2Partial1),    ['npm(foo) >= 0.0.0', 'npm(foo) < 0.1.0']);
+    assert.deepEqual(d2r(caretUnstable2Partial2),    ['npm(foo) >= 0.0.0', 'npm(foo) < 0.1.0']);
+    assert.deepEqual(d2r(caretPreRelease),           ['npm(foo) >= 1.2.3-beta.2', 'npm(foo) < 2.0.0']);
+    assert.deepEqual(d2r(caretUnstablePreRelease),   ['npm(foo) >= 0.0.3-beta.2', 'npm(foo) < 0.0.4']);
   });
 
   it('ignores || ranges', () => {


### PR DESCRIPTION
For dependencies with operators, rpmbuild always expects a space
between the operator and the dependency, i. e.:

| Requires: $package <= 2.11.0

instead of:

| Requires: $package <=2.11.0.