### PR TITLE
add the namespace into the generated RPM name

### DIFF
--- a/lib/npm_helpers.js
+++ b/lib/npm_helpers.js
@@ -3,7 +3,14 @@ module.exports.npmUrl = (name, version) => {
 }
 
 module.exports.getRpmPackageName = (nodePackageName) => {
-  return `nodejs-${this.rsplit(nodePackageName, '/')[1]}`;
+  const parts = this.rsplit(nodePackageName, '/');
+  const group = parts[0].replace('@', '');
+  const name = parts[1];
+  if (group !== '') {
+    return `nodejs-${group}-${name}`;
+  } else {
+    return `nodejs-${name}`;
+  }
 }
 
 module.exports.rsplit = (string, character) => {

--- a/test/npm_helpers_test.js
+++ b/test/npm_helpers_test.js
@@ -16,7 +16,7 @@ describe('getRpmPackageName', () => {
 
   it('works with a namespaces package', () => {
     const name = npmHelpers.getRpmPackageName('@group/foo');
-    assert.equal(name, 'nodejs-foo');
+    assert.equal(name, 'nodejs-group-foo');
   });
 });
 


### PR DESCRIPTION
otherwise we might end up with clashes in RPM names where multiple
groups/namespaces use the same name internally