### PR TITLE
Explicitly add the npm module name in spec file

### DIFF
--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -180,7 +180,7 @@ function generateSpecFile(npm_module, files, dependencies, release, template_nam
   } else {
     replacements['DEPENDENCIES'] = dependenciesToRequires(npm_module['dependencies'], scl);
     replacements['PROVIDES'] = [];
-    replacements['SOURCES'] = ['Source0: ' + npmUrl('%{npm_name}', '%{version}')];
+    replacements['SOURCES'] = ['Source0: ' + npmUrl(npm_module.name, '%{version}')];
   }
 
   const spec_file = fs.readFileSync(template_name, { encoding: 'utf8' });


### PR DESCRIPTION
Otherwise, @ modules (e.g. @theforeman/vendor) will generate incorrect
spec when using single strategy