### PR TITLE
Purge the NPM registry output from duplicate entries

### DIFF
--- a/bin/generate_npm_tarball.sh
+++ b/bin/generate_npm_tarball.sh
@@ -1,28 +1,53 @@
 #!/bin/bash
 
 if [ $# -lt 2 ]; then
-  echo "usage: $0 PACKAGE[@VERSION] OUTPUT.TGZ [USE NODEJS 6]"
+  echo "usage: $0 PACKAGE[@VERSION] OUTPUT.TGZ [USE NODEJS 6] [SPECFILE_FOR_PURGE]"
   exit 1
 fi
 package=$1
 output=$(pwd)/$2
 usenodejs6=${3:-false}
+specfile="$4"
 wd=$(mktemp -d)
 trap "rm -rf '$wd'" EXIT INT TERM
 
 create_cache() {
   if [[ $usenodejs6 == true ]];then
     node_modules/npm/bin/npm-cli.js install --cache $wd/cache $package --no-shrinkwrap --no-optional --production --verbose
+    (cd $wd/cache && find -type f | sort) > $wd/to-compress
   else
+    if [[ -n $specfile ]] ; then
+      mkdir $wd/spec
+      spectool --get-files --directory $wd/spec "$specfile"
+
+      for filename in $wd/spec/*.tgz ; do
+        if [[ "$filename" != "*-registry.npmjs.org.tgz" ]] ; then
+          npm cache add --cache $wd/cache $filename
+        fi
+      done
+    fi
+
+    (cd $wd/cache && find -type f | sort) > $wd/cache-primed
+
     npm install --cache $wd/cache $package --no-shrinkwrap --no-optional --production --verbose
+
+    (cd $wd/cache && find -type f | sort) > $wd/cache-full
+
+    grep --invert-match --file $wd/cache-primed $wd/cache-full > $wd/to-compress
   fi
 }
+
+if [[ -n $specfile ]] ; then
+  specfile=$(realpath "$specfile")
+fi
 
 mkdir $wd/cache $wd/install
 cd $wd/install
 if [[ $usenodejs6 == true ]];then
   npm install npm@3.x
 fi
+
 create_cache
+
 cd $wd/cache
-tar --create --gzip --file $output .
+tar --create --auto-compress --file $output --files-from $wd/to-compress

--- a/bin/npm2rpm.js
+++ b/bin/npm2rpm.js
@@ -90,11 +90,11 @@ tar_stream.on('finish', () => {
       // Dependencies come as name@version but sometimes as @name@version
       const dependencies = deps.map(dependency => rsplit(dependency, '@'));
 
-      writeSpecFile(npm_module, files, dependencies, npm2rpm.release, npm2rpm.template, npm2rpm.output, npm2rpm.scl);
+      specfile = writeSpecFile(npm_module, files, dependencies, npm2rpm.release, npm2rpm.template, npm2rpm.output, npm2rpm.scl);
 
       if (dependencies.length > 0) {
         console.log(' - Generating npm cache tgz... '.bold)
-        createNpmCacheTar(npm_module, npm2rpm.output, npm2rpm.useNodejs6);
+        createNpmCacheTar(npm_module, npm2rpm.output, npm2rpm.useNodejs6, specfile);
       }
     });
   } else {
@@ -106,13 +106,14 @@ function writeSpecFile(npmModule, files, dependencies, release, template, specDi
   const content = specFileGenerator(npmModule, files, dependencies, release, template, scl);
   const filename = path.join(specDir, `${getRpmPackageName(npmModule.name)}.spec`);
   fs.writeFileSync(filename, content);
+  return filename;
 }
 
-function createNpmCacheTar(npm_module, outputDir, useNodejs6) {
+function createNpmCacheTar(npm_module, outputDir, useNodejs6, specfile) {
   const command = path.join(__dirname, 'generate_npm_tarball.sh');
   const pkg = `${npm_module.name}@${npm_module.version}`;
   const filename = path.join(outputDir, getCacheFilename(getRpmPackageName(npm_module.name), npm_module.version));
-  execSync([command, pkg, filename, useNodejs6].join(' '), {stdio: [0,1,2]});
+  execSync([command, pkg, filename, useNodejs6, specfile].join(' '), {stdio: [0,1,2]});
 }
 
 function createTempDir() {


### PR DESCRIPTION
This is based on what I wrote[1]. The short summary is NPM offline installs are achieved by having a cache of responses from the NPM registry. This cache was already primed with tarballs in the build process (using npm cache add in the RPM spec), but the tarball contained the same duplicated files.

By priming the cache in the same way and excluding the duplicated entries space can be saved. For @theforeman/builder 10.1.7 the compressed responses are reduced from 6.7M to 4.6M, about 31%.

[1]: https://community.theforeman.org/t/trimming-foreman-packaging-branches/29189/7