### PR TITLE
Update CI to test on NodeJS 22 & 24 and add release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,8 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - 18
-          - 16
-          - 14
+          - '24'
+          - '22'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm publish

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dLobatog/npm2rpm.git"
+    "url": "git+https://github.com/theforeman/npm2rpm.git"
   },
   "keywords": [
     "npm",
@@ -22,7 +22,7 @@
   "author": "Daniel Lobato Garcia <me@daniellobato.me>",
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/dLobatog/npm2rpm/issues"
+    "url": "https://github.com/theforeman/npm2rpm/issues"
   },
   "dependencies": {
     "colors": "^1.1.2",
@@ -38,7 +38,7 @@
   "devDependencies": {
     "mocha": ">= 3.0.2 < 6.0"
   },
-  "homepage": "https://github.com/dLobatog/npm2rpm#readme",
+  "homepage": "https://github.com/theforeman/npm2rpm#readme",
   "preferGlobal": true,
   "bin": {
     "npm2rpm": "bin/npm2rpm.js",


### PR DESCRIPTION
See individual commits for details. This prepares for a 7.0 release.