### PR TITLE
Work around RHEL-137712

### DIFF
--- a/bundle.mustache
+++ b/bundle.mustache
@@ -12,6 +12,10 @@ URL: {{{PROJECTURL}}}
 {{/each}}
 BuildRequires: npm >= 7
 BuildRequires: nodejs-packaging
+%if 0%{?rhel} == 10
+# https://issues.redhat.com/browse/RHEL-137712 is fixed in RHEL 10.3
+BuildRequires: /usr/bin/node
+%endif
 BuildArch: noarch
 ExclusiveArch: %{nodejs_arches} noarch
 

--- a/single.mustache
+++ b/single.mustache
@@ -10,6 +10,10 @@ URL: {{{PROJECTURL}}}
 {{{.}}}
 {{/each}}
 BuildRequires: nodejs-packaging
+%if 0%{?rhel} == 10
+# https://issues.redhat.com/browse/RHEL-137712 is fixed in RHEL 10.3
+BuildRequires: /usr/bin/node
+%endif
 {{#each DEPENDENCIES}}
 Requires: {{{.}}}
 {{/each}}


### PR DESCRIPTION
On EL10 the nodejs-packaging package requires node to determine the version, but doesn't require it.

Link: https://issues.redhat.com/browse/RHEL-137712