### PR TITLE
Set engines.node >= 22 to match CI-tested versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   ],
   "author": "Daniel Lobato Garcia <me@daniellobato.me>",
   "license": "GPL-3.0",
+  "engines": {
+    "node": ">=22"
+  },
   "bugs": {
     "url": "https://github.com/theforeman/npm2rpm/issues"
   },


### PR DESCRIPTION
CI was updated to test only Node 22 and 24 (#88), dropping
14/16/18. But package.json had no engines field, so users on old Node
get no warning at install time.

This adds `"engines": { "node": ">=22" }` so npm warns users when
their Node version is unsupported.

The engines field is advisory by default — it warns but does not block
installation. Users who have `engine-strict=true` configured get a
hard failure, which is the stricter behavior they opted into.

Docs:
- engines: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#engines
- engine-strict: https://docs.npmjs.com/cli/v11/using-npm/config#engine-strict