### PR TITLE
feature: Avoid bundling native binaries

### DIFF
--- a/bin/generate_npm_tarball.sh
+++ b/bin/generate_npm_tarball.sh
@@ -38,9 +38,9 @@ create_cache() {
   (cd $wd/cache && find -type f | sort) > $wd/cache-primed
 
   if [[ $legacypeerdeps == true ]];then
-    npm install --legacy-peer-deps --cache $wd/cache $package --no-shrinkwrap --no-optional --production --verbose
+    npm install --legacy-peer-deps --cache $wd/cache $package --no-shrinkwrap --no-optional --production --ignore-scripts --verbose
   else
-    npm install --cache $wd/cache $package --no-shrinkwrap --no-optional --production --verbose
+    npm install --cache $wd/cache $package --no-shrinkwrap --no-optional --production --ignore-scripts --verbose
   fi
 
   (cd $wd/cache && find -type f | sort) > $wd/cache-full

--- a/bin/generate_npm_tarball.sh
+++ b/bin/generate_npm_tarball.sh
@@ -10,12 +10,22 @@ package=$1
 output=$(pwd)/$2
 specfile="$3"
 legacypeerdeps=${4:-false}
+cachedir=${5:-}  # Optional: directory with cached dependency tarballs
 wd=$(mktemp -d)
 trap "rm -rf '$wd'" EXIT INT TERM
 
 create_cache() {
   if [[ -n $specfile ]] ; then
     mkdir $wd/spec
+
+    # Check for cached tarballs from binary analysis (passed as parameter)
+    if [[ -n "$cachedir" && -d "$cachedir" ]] ; then
+      # Copy cached tarballs instead of downloading
+      echo "Using cached dependency tarballs from $cachedir"
+      find "$cachedir" -maxdepth 1 -name '*.tgz' -type f -exec cp -v -t $wd/spec/ {} +
+    fi
+
+    # Download any missing tarballs with spectool
     spectool --get-files --directory $wd/spec "$specfile"
 
     for filename in $wd/spec/*.tgz ; do

--- a/bin/npm2rpm.js
+++ b/bin/npm2rpm.js
@@ -14,6 +14,8 @@ const normalizeData = require('normalize-package-data');
 // Our own deps
 const {npmUrl, rsplit, getCacheFilename, getRpmPackageName} = require('../lib/npm_helpers.js');
 const specFileGenerator = require('../lib/spec_file_generator.js');
+const binaryDetector = require('../lib/binary_detector.js');
+const dependencyAnalyzer = require('../lib/dependency_analyzer.js');
 
 console.log('---- npm2rpm ----'.green.bold);
 console.log('-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-'.rainbow.bgWhite);
@@ -25,6 +27,9 @@ npm2rpm
 .option('-t, --template [template]', "RPM .spec template to use")
 .option('-o, --output [directory]', "Directory to output files to")
 .option('-p, --use-legacy-peer-deps [useLegacyPeerDeps]', "Adds --legacy-peer-deps during npm install")
+.option('--check-binaries', 'Check for native binaries and WebAssembly (required for Fedora packaging)')
+.option('--concurrency <number>', 'Number of parallel dependency downloads (default: 5)', parseInt)
+.option('--verbose-binaries', 'Show detailed binary detection output')
 .parse(process.argv);
 
 // If a name is not provided, then npm2rpm.name defaults to calling 'commander' name() function
@@ -50,6 +55,10 @@ if (npm2rpm.useLegacyPeerDeps === undefined) {
   npm2rpm.useLegacyPeerDeps = false;
 }
 
+if (npm2rpm.concurrency === undefined) {
+  npm2rpm.concurrency = 5;
+}
+
 const url = npmUrl(npm2rpm.name, npm2rpm.version);
 console.log(' - Starting npm module download: '.bold + url );
 const tmpDir = createTempDir();
@@ -61,7 +70,7 @@ tar_stream.on('error', (error) => {
     console.log('Are you sure that the module name and version can be found on npmjs.org?'.bold);
   }
 })
-tar_stream.on('finish', () => {
+tar_stream.on('finish', async () => {
   console.log(' - Finished extracting for '.bold + npm2rpm.name);
   console.log(' - Reading package.json for '.bold + npm2rpm.name);
   const npm_module = readPackageJson(path.join(tmpDir, 'package', 'package.json'),
@@ -74,6 +83,34 @@ tar_stream.on('finish', () => {
     fs.mkdirSync(npm2rpm.output);
   }
 
+  // Binary checking is OPT-IN via --check-binaries flag
+  let mainPackageBinaries = null;
+  let cacheDir = null; // Cache directory for dependency tarballs
+  let cacheDirCleanup = null; // Cleanup callback for temp cache directory
+  if (npm2rpm.checkBinaries) {
+    console.log(' - Scanning main package for binaries...'.bold);
+    const mainScan = binaryDetector.scanForBinaries(path.join(tmpDir, 'package'));
+
+    if (mainScan.hasBinaries) {
+      console.warn('');
+      console.warn('⚠ WARNING: Main package contains native binaries/Wasm:'.yellow);
+      mainScan.files.forEach(f => console.warn('  -', f));
+      console.warn('');
+      console.warn('For Fedora packaging, these binaries must be stripped before building.'.yellow);
+      console.warn('Generated spec file will include a %prep section to strip these binaries.'.yellow);
+      console.warn('');
+      console.warn('NOTE: If this package requires these binaries to be rebuilt:'.yellow);
+      console.warn('  - Ensure package.json includes proper build scripts');
+      console.warn('  - Add appropriate BuildRequires to the spec (e.g., node-gyp, gcc-c++)');
+      console.warn('  - The %build section may need manual adjustment');
+      console.warn('');
+
+      mainPackageBinaries = mainScan.files;
+    } else {
+      console.log('   ✓ No binaries found in main package'.green);
+    }
+  }
+
   if (npm2rpm.strategy === 'bundle') {
     npm_remote_ls.config({
       development: false,
@@ -81,34 +118,93 @@ tar_stream.on('finish', () => {
     });
 
     console.log(' - Fetching flattened list of production dependencies for '.bold + npm_module.name);
-    npm_remote_ls.ls(npm_module.name, npm_module.version, true, (deps) => {
+    npm_remote_ls.ls(npm_module.name, npm_module.version, true, async (deps) => {
       // Dependencies come as name@version but sometimes as @name@version
       const dependencies = deps.map(dependency => rsplit(dependency, '@'));
 
-      specfile = writeSpecFile(npm_module, files, dependencies, npm2rpm.release, npm2rpm.template, npm2rpm.output, npm2rpm.useLegacyPeerDeps);
+      let analysis;
 
-      if (dependencies.length > 0) {
+      // Binary checking is OPT-IN via --check-binaries flag
+      if (npm2rpm.checkBinaries) {
+        console.log(' - Analyzing dependencies for native binaries...'.bold);
+
+        // Create temp cache directory to save downloaded tarballs
+        // This avoids re-downloading when spectool runs later
+        const cacheDirObj = tmp.dirSync({ prefix: 'npm2rpm-cache-', unsafeCleanup: true });
+        cacheDir = cacheDirObj.name;
+        cacheDirCleanup = () => cacheDirObj.removeCallback();
+
+        analysis = await dependencyAnalyzer.analyzeAndCategorizeDependencies(
+          dependencies.map(([name, version]) => ({name, version})),
+          npm_module,
+          {
+            concurrency: npm2rpm.concurrency,
+            verbose: npm2rpm.verboseBinaries,
+            cacheDir: cacheDir
+          }
+        );
+
+        console.log(`   ✓ ${analysis.bundled.length} dependencies can be bundled`.green);
+        if (analysis.unbundled.length > 0) {
+          console.log(`   ⚠ ${analysis.unbundled.length} dependencies contain binaries (will be unbundled):`.yellow);
+          analysis.unbundled.forEach(d => {
+            const depType = analysis.unbundledRuntime.includes(d) ? 'runtime' : 'dev';
+            console.log(`     - ${d.name}@${d.version}`.yellow + ` [${depType}]`.dim);
+            if (npm2rpm.verboseBinaries && d.binaryFiles.length > 0) {
+              d.binaryFiles.slice(0, 3).forEach(f => console.log(`       • ${f}`.dim));
+              if (d.binaryFiles.length > 3) {
+                console.log(`       ... and ${d.binaryFiles.length - 3} more`.dim);
+              }
+            }
+          });
+          console.log('');
+          console.log('   These dependencies will be added as Requires/BuildRequires instead of bundled.'.yellow);
+          console.log('   For Fedora: these must be packaged separately as RPMs first.'.yellow);
+        }
+      } else {
+        // Default behavior: bundle everything (no binary checking)
+        analysis = {
+          bundled: dependencies.map(([name, version]) => ({name, version})),
+          unbundled: [],
+          unbundledRuntime: [],
+          unbundledDev: []
+        };
+      }
+
+      specfile = writeSpecFile(npm_module, files, analysis, mainPackageBinaries, npm2rpm.release, npm2rpm.template, npm2rpm.output, npm2rpm.useLegacyPeerDeps);
+
+      if (analysis.bundled.length > 0) {
         console.log(' - Generating npm cache tgz... '.bold)
-        createNpmCacheTar(npm_module, npm2rpm.output, specfile, npm2rpm.useLegacyPeerDeps);
+        createNpmCacheTar(npm_module, npm2rpm.output, specfile, npm2rpm.useLegacyPeerDeps, cacheDir);
+      }
+
+      // Clean up cache directory after we're done
+      if (cacheDirCleanup) {
+        cacheDirCleanup();
       }
     });
   } else {
-    writeSpecFile(npm_module, files, [], npm2rpm.release, npm2rpm.template, npm2rpm.output, npm2rpm.useLegacyPeerDeps);
+    // Single strategy - pass empty analysis (no dependencies)
+    const analysis = { bundled: [], unbundled: [], unbundledRuntime: [], unbundledDev: [] };
+    writeSpecFile(npm_module, files, analysis, mainPackageBinaries, npm2rpm.release, npm2rpm.template, npm2rpm.output, npm2rpm.useLegacyPeerDeps);
   }
 })
 
-function writeSpecFile(npmModule, files, dependencies, release, template, specDir, use_legacy_peer_deps) {
-  const content = specFileGenerator(npmModule, files, dependencies, release, template, use_legacy_peer_deps);
+function writeSpecFile(npmModule, files, analysis, mainPackageBinaries, release, template, specDir, use_legacy_peer_deps) {
+  const content = specFileGenerator(npmModule, files, analysis, mainPackageBinaries, release, template, use_legacy_peer_deps);
   const filename = path.join(specDir, `${getRpmPackageName(npmModule.name)}.spec`);
   fs.writeFileSync(filename, content);
   return filename;
 }
 
-function createNpmCacheTar(npm_module, outputDir, specfile, useLegacyPeerDeps) {
+function createNpmCacheTar(npm_module, outputDir, specfile, useLegacyPeerDeps, cacheDir) {
   const command = path.join(__dirname, 'generate_npm_tarball.sh');
   const pkg = `${npm_module.name}@${npm_module.version}`;
   const filename = path.join(outputDir, getCacheFilename(getRpmPackageName(npm_module.name), npm_module.version));
-  execSync([command, pkg, filename, specfile, useLegacyPeerDeps].join(' '), {stdio: [0,1,2]});
+  const args = cacheDir
+    ? [command, pkg, filename, specfile, useLegacyPeerDeps, cacheDir].join(' ')
+    : [command, pkg, filename, specfile, useLegacyPeerDeps].join(' ');
+  execSync(args, {stdio: [0,1,2]});
 }
 
 function createTempDir() {

--- a/bundle.mustache
+++ b/bundle.mustache
@@ -16,12 +16,18 @@ BuildRequires: nodejs-packaging
 # https://issues.redhat.com/browse/RHEL-137712 is fixed in RHEL 10.3
 BuildRequires: /usr/bin/node
 %endif
+{{#each UNBUNDLED_BUILD_REQUIRES}}
+BuildRequires: npm({{{.}}})
+{{/each}}
 BuildArch: noarch
 ExclusiveArch: %{nodejs_arches} noarch
 
 Provides: npm(%{npm_name}) = %{version}
 {{#each PROVIDES}}
 Provides: bundled(npm({{{name}}})) = {{{version}}}
+{{/each}}
+{{#each UNBUNDLED_REQUIRES}}
+Requires: npm({{{.}}})
 {{/each}}
 AutoReq: no
 AutoProv: no
@@ -43,6 +49,20 @@ done
 PREP_TEMP=$(mktemp -d)
 tar xzf %{SOURCE0} -C $PREP_TEMP
 # Apply patches and remove binaries here if needed
+{{#if MAIN_PACKAGE_HAS_BINARIES}}
+# Remove pre-compiled binaries detected in source
+# Fedora policy requires building from source or excluding binaries
+# The following files were detected as native binaries or WebAssembly:
+{{#each PREP_BINARY_STRIP.files}}
+#   {{{.}}}
+{{/each}}
+# If these binaries are needed at runtime, ensure package.json has build scripts
+# and add appropriate BuildRequires (e.g., node-gyp, gcc-c++, *-devel)
+
+rm -vf{{#each PREP_BINARY_STRIP.files}} \
+  {{{.}}}{{/each}}
+
+{{/if}}
 tar czf %{_builddir}/%{npm_name}-%{version}.tgz -C $PREP_TEMP package
 rm -rf $PREP_TEMP
 

--- a/bundle.mustache
+++ b/bundle.mustache
@@ -39,8 +39,16 @@ done
 
 %setup -T -q -a {{{PROVIDES.length}}} -D -n %{npm_cache_dir}
 
+# Extract Source0 to allow patching
+PREP_TEMP=$(mktemp -d)
+tar xzf %{SOURCE0} -C $PREP_TEMP
+# Apply patches and remove binaries here if needed
+tar czf %{_builddir}/%{npm_name}-%{version}.tgz -C $PREP_TEMP package
+rm -rf $PREP_TEMP
+
 %build
-npm install {{{LEGACY_PEER_DEPS}}}--offline --cache %{_builddir}/%{npm_cache_dir} --package-lock false --omit optional --install-strategy shallow %{npm_name}@%{version}
+# Install from the (possibly patched) tarball instead of by name@version
+npm install {{{LEGACY_PEER_DEPS}}}--offline --cache %{_builddir}/%{npm_cache_dir} --package-lock false --omit optional --install-strategy shallow %{_builddir}/%{npm_name}-%{version}.tgz
 
 %install
 mkdir -p %{buildroot}%{nodejs_sitelib}/%{npm_name}

--- a/lib/binary_detector.js
+++ b/lib/binary_detector.js
@@ -1,0 +1,184 @@
+/**
+ * Binary Detection Module
+ *
+ * Detects native binaries and WebAssembly modules in npm packages.
+ * Based on detection logic from undici-sources.sh
+ *
+ * Detection methods (in order of performance):
+ * 1. Extension check - fast, catches obvious cases
+ * 2. MIME type check - medium speed, high accuracy using 'file' command
+ * 3. Embedded Wasm check - slowest, catches base64-encoded Wasm
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+/**
+ * Scan a directory for native binaries and WebAssembly modules
+ * @param {string} dir - Directory path to scan
+ * @returns {Object} - { hasBinaries: boolean, files: string[] }
+ */
+function scanForBinaries(dir) {
+  const binaryFiles = [];
+
+  // Find all files in the directory
+  const files = getAllFiles(dir);
+
+  for (const file of files) {
+    const relativePath = path.relative(dir, file);
+
+    // Check by extension (fast)
+    if (hasBinaryExtension(file)) {
+      binaryFiles.push(relativePath);
+      continue;
+    }
+
+    // Check by MIME type (medium speed, requires file command)
+    if (isBinaryByMimeType(file)) {
+      binaryFiles.push(relativePath);
+      continue;
+    }
+
+    // Check for embedded Wasm (slow, only for text-like files)
+    if (hasEmbeddedWasm(file)) {
+      binaryFiles.push(relativePath);
+      continue;
+    }
+  }
+
+  return {
+    hasBinaries: binaryFiles.length > 0,
+    files: binaryFiles
+  };
+}
+
+/**
+ * Recursively get all files in a directory
+ * @param {string} dir - Directory to search
+ * @returns {string[]} - Array of absolute file paths
+ */
+function getAllFiles(dir) {
+  const results = [];
+
+  function walk(currentPath) {
+    const entries = fs.readdirSync(currentPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentPath, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return results;
+}
+
+/**
+ * Check if a file has a binary extension
+ * @param {string} filepath - Path to file
+ * @returns {boolean}
+ */
+function hasBinaryExtension(filepath) {
+  const binaryExtensions = [
+    '.node',   // Node.js native addon
+    '.so',     // Linux shared library
+    '.dylib',  // macOS dynamic library
+    '.dll',    // Windows DLL
+    '.exe',    // Windows executable
+    '.wasm',   // WebAssembly module
+  ];
+
+  const ext = path.extname(filepath).toLowerCase();
+
+  // Check exact extensions
+  if (binaryExtensions.includes(ext)) {
+    return true;
+  }
+
+  // Check for versioned .so files (e.g., .so.1, .so.1.2.3)
+  if (filepath.match(/\.so\.\d+/)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Check if a file is a binary using 'file' command MIME type
+ * @param {string} filepath - Path to file
+ * @returns {boolean}
+ */
+function isBinaryByMimeType(filepath) {
+  try {
+    // Use file command with --mime-type for clean output
+    // -N: don't pad filenames
+    // --mime-type: only show MIME type
+    const output = execSync(`file -N --mime-type "${filepath}"`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'] // suppress stderr
+    }).trim();
+
+    // Output format: "filepath: mime/type"
+    const mimeType = output.split(':')[1]?.trim();
+
+    if (!mimeType) {
+      return false;
+    }
+
+    // MIME types for native binaries and WebAssembly
+    const binaryMimeTypes = [
+      'application/x-executable',           // ELF executables
+      'application/x-pie-executable',       // Position Independent ELF
+      'application/x-sharedlib',            // ELF shared libraries
+      'application/x-mach-binary',          // macOS Mach-O
+      'application/x-dosexec',              // Windows PE/COFF (older)
+      'application/vnd.microsoft.portable-executable', // Windows PE (newer)
+      'application/wasm',                   // WebAssembly modules
+    ];
+
+    return binaryMimeTypes.includes(mimeType);
+  } catch (error) {
+    // If file command fails, assume not a binary
+    return false;
+  }
+}
+
+/**
+ * Check if a file contains base64-encoded WebAssembly
+ * Wasm files start with magic bytes 0x00 0x61 0x73 0x6d
+ * In base64, this is "AGFzb"
+ * @param {string} filepath - Path to file
+ * @returns {boolean}
+ */
+function hasEmbeddedWasm(filepath) {
+  try {
+    // Only check text-like files (skip obvious binaries)
+    if (hasBinaryExtension(filepath)) {
+      return false;
+    }
+
+    // Read file content as text
+    const content = fs.readFileSync(filepath, 'utf8');
+
+    // Check for Wasm magic bytes in base64
+    // AGFzb is the base64 encoding of the first 4 bytes of a Wasm file
+    return content.includes('AGFzb');
+  } catch (error) {
+    // If file is not readable as text, it's probably a binary
+    // which would have been caught by other checks
+    return false;
+  }
+}
+
+module.exports = {
+  scanForBinaries,
+  hasBinaryExtension,
+  isBinaryByMimeType,
+  hasEmbeddedWasm,
+};

--- a/lib/dependency_analyzer.js
+++ b/lib/dependency_analyzer.js
@@ -1,0 +1,224 @@
+/**
+ * Dependency Analyzer Module
+ *
+ * Downloads and analyzes npm dependencies for native binaries and WebAssembly.
+ * Determines which dependencies can be bundled vs must be packaged separately.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const tmp = require('tmp');
+const request = require('request');
+const tar = require('tar');
+const binaryDetector = require('./binary_detector');
+const { npmUrl } = require('./npm_helpers');
+
+/**
+ * Analyze a single dependency for binaries
+ * @param {string} name - Package name
+ * @param {string} version - Package version
+ * @param {Object} options - { cacheDir: string } - optional cache directory to save tarballs
+ * @returns {Promise<Object>} - { name, version, hasBinaries, binaryFiles }
+ */
+async function analyzeDependency(name, version, options = {}) {
+  let tmpDir = null;
+
+  try {
+    // Download and extract the package
+    const downloadResult = await downloadAndExtract(name, version, options);
+    tmpDir = downloadResult.extractedDir;
+
+    // Scan for binaries
+    const scanResult = binaryDetector.scanForBinaries(tmpDir);
+
+    return {
+      name,
+      version,
+      hasBinaries: scanResult.hasBinaries,
+      binaryFiles: scanResult.files,
+      tarballPath: downloadResult.tarballPath // Include path to cached tarball
+    };
+  } catch (error) {
+    // If download or analysis fails, treat as having binaries (safer default)
+    console.warn(`Warning: Failed to analyze ${name}@${version}: ${error.message}`);
+    return {
+      name,
+      version,
+      hasBinaries: true,
+      binaryFiles: [],
+      error: error.message
+    };
+  } finally {
+    // Clean up temp directory (but keep cached tarball if cacheDir was specified)
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * Analyze all dependencies in parallel
+ * @param {Array} dependencies - [{name, version}, ...]
+ * @param {Object} options - { concurrency: number, cacheDir: string }
+ * @returns {Promise<Object>} - { bundled: [], unbundled: [] }
+ */
+async function analyzeDependencies(dependencies, options = {}) {
+  const concurrency = options.concurrency || 5;
+  const results = [];
+
+  // Process dependencies in batches to limit concurrency
+  for (let i = 0; i < dependencies.length; i += concurrency) {
+    const batch = dependencies.slice(i, i + concurrency);
+    const batchResults = await Promise.all(
+      batch.map(dep => analyzeDependency(dep.name, dep.version, options))
+    );
+    results.push(...batchResults);
+
+    // Progress indicator
+    if (options.verbose) {
+      console.log(`   Analyzed ${Math.min(i + concurrency, dependencies.length)}/${dependencies.length} dependencies`);
+    }
+  }
+
+  // Split into bundled (no binaries) and unbundled (has binaries)
+  const bundled = results.filter(r => !r.hasBinaries);
+  const unbundled = results.filter(r => r.hasBinaries);
+
+  return { bundled, unbundled };
+}
+
+/**
+ * Helper: Find the extracted package directory in a temp directory
+ * @param {string} tmpDirPath - Path to temp directory
+ * @returns {string|null} - Name of the package directory, or null if not found
+ */
+function findPackageDir(tmpDirPath) {
+  const entries = fs.readdirSync(tmpDirPath);
+  return entries.find(entry => {
+    const fullPath = path.join(tmpDirPath, entry);
+    try {
+      const isDir = fs.statSync(fullPath).isDirectory();
+      const hasPackageJson = isDir && fs.existsSync(path.join(fullPath, 'package.json'));
+      return hasPackageJson;
+    } catch (e) {
+      return false;
+    }
+  });
+}
+
+/**
+ * Helper: Extract tarball and find package directory
+ * @param {string} tarballPath - Path to tarball file
+ * @param {string} tmpDirPath - Path to extract to
+ * @param {string} name - Package name (for error messages)
+ * @param {string} version - Package version (for error messages)
+ * @returns {Promise<string>} - Path to extracted package directory
+ */
+function extractAndFind(tarballPath, tmpDirPath, name, version) {
+  return new Promise((resolve, reject) => {
+    const extractStream = tar.extract({ cwd: tmpDirPath });
+    fs.createReadStream(tarballPath)
+      .on('error', error => {
+        reject(new Error(`Failed to read ${name}@${version}: ${error.message}`));
+      })
+      .pipe(extractStream)
+      .on('error', error => {
+        reject(new Error(`Failed to extract ${name}@${version}: ${error.message}`));
+      })
+      .on('finish', () => {
+        const packageDir = findPackageDir(tmpDirPath);
+        if (!packageDir) {
+          reject(new Error(`Package directory not found for ${name}@${version}`));
+          return;
+        }
+        resolve(path.join(tmpDirPath, packageDir));
+      });
+  });
+}
+
+/**
+ * Download and extract npm package to temp directory
+ * @param {string} name - Package name
+ * @param {string} version - Package version
+ * @param {Object} options - { cacheDir: string } - optional cache directory to save tarball
+ * @returns {Promise<Object>} - { extractedDir: string, tarballPath: string }
+ */
+async function downloadAndExtract(name, version, options = {}) {
+  const url = npmUrl(name, version);
+  const tmpDir = tmp.dirSync({ prefix: 'npm2rpm-dep-', unsafeCleanup: true });
+  const tarballFilename = url.split('/').pop();
+
+  try {
+    // Determine cache path if caching is enabled
+    const tarballPath = options.cacheDir ? path.join(options.cacheDir, tarballFilename) : null;
+
+    // If already cached, extract from cache
+    if (tarballPath && fs.existsSync(tarballPath)) {
+      const extractedDir = await extractAndFind(tarballPath, tmpDir.name, name, version);
+      return { extractedDir, tarballPath };
+    }
+
+    // Download to temp location
+    const tmpTarball = path.join(tmpDir.name, tarballFilename);
+    await new Promise((resolve, reject) => {
+      request.get(url)
+        .on('error', error => reject(new Error(`Failed to download ${name}@${version}: ${error.message}`)))
+        .pipe(fs.createWriteStream(tmpTarball))
+        .on('error', error => reject(new Error(`Failed to write ${name}@${version}: ${error.message}`)))
+        .on('finish', resolve);
+    });
+
+    // Copy to cache if requested
+    if (tarballPath) {
+      try {
+        fs.copyFileSync(tmpTarball, tarballPath);
+      } catch (error) {
+        console.warn(`Warning: Failed to cache ${name}@${version}: ${error.message}`);
+      }
+    }
+
+    // Extract and find package directory
+    const extractedDir = await extractAndFind(tmpTarball, tmpDir.name, name, version);
+    return { extractedDir, tarballPath };
+
+  } catch (error) {
+    tmpDir.removeCallback();
+    throw error;
+  }
+}
+
+/**
+ * Analyze dependencies and categorize them
+ * Helper function that also separates runtime vs dev dependencies
+ * @param {Array} allDependencies - All dependencies to analyze
+ * @param {Object} packageJson - The main package's package.json
+ * @param {Object} options - Analysis options
+ * @returns {Promise<Object>} - { bundled, unbundledRuntime, unbundledDev }
+ */
+async function analyzeAndCategorizeDependencies(allDependencies, packageJson, options = {}) {
+  const analysis = await analyzeDependencies(allDependencies, options);
+
+  // Separate unbundled into runtime vs dev
+  const runtimeDeps = new Set(Object.keys(packageJson.dependencies || {}));
+  const devDeps = new Set(Object.keys(packageJson.devDependencies || {}));
+
+  // Transitive dependencies (not in package.json) are treated as runtime dependencies
+  const unbundledRuntime = analysis.unbundled.filter(dep =>
+    runtimeDeps.has(dep.name) || (!runtimeDeps.has(dep.name) && !devDeps.has(dep.name))
+  );
+  const unbundledDev = analysis.unbundled.filter(dep => devDeps.has(dep.name));
+
+  return {
+    bundled: analysis.bundled,
+    unbundledRuntime,
+    unbundledDev,
+    unbundled: analysis.unbundled // Keep full list for backward compat
+  };
+}
+
+module.exports = {
+  analyzeDependency,
+  analyzeDependencies,
+  downloadAndExtract,
+  analyzeAndCategorizeDependencies,
+};

--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -19,10 +19,17 @@ function sorted(items) {
 }
 
 function dependenciesToSources(name, deps) {
-  const sources = deps.map((dependency, index) => {
-    return `Source${index}: ${npmUrl(dependency['name'], dependency['version'])}`;
+  // Main package is Source0 for easier patching in %prep
+  const sources = [`Source0: ${npmUrl(name, '%{version}')}`];
+
+  // Filter out main package from deps (it's already Source0) and add remaining dependencies
+  const depsOnly = deps.filter(dep => dep.name !== name);
+  depsOnly.forEach((dependency, index) => {
+    sources.push(`Source${index + 1}: ${npmUrl(dependency['name'], dependency['version'])}`);
   });
-  sources.push(`Source${deps.length}: ${getCacheFilename(getRpmPackageName(name), '%{version}')}`);
+
+  // Cache tarball is last
+  sources.push(`Source${depsOnly.length + 1}: ${getCacheFilename(getRpmPackageName(name), '%{version}')}`);
   return sources;
 }
 

--- a/lib/spec_file_generator.js
+++ b/lib/spec_file_generator.js
@@ -161,9 +161,24 @@ function getLegacyPeerDeps(use_legacy_peer_deps) {
   }
 }
 
-function generateSpecFile(npm_module, files, dependencies, release, template_name, use_legacy_peer_deps) {
+function generateSpecFile(npm_module, files, analysis, mainPackageBinaries, release, template_name, use_legacy_peer_deps) {
   for (binary in npm_module.bin) {
     npm_module.bin[binary] = npm_module.bin[binary].replace(/^\.\//, '');
+  }
+
+  // Handle both old API (dependencies array) and new API (analysis object)
+  let bundled, unbundledRuntime, unbundledDev;
+  if (Array.isArray(analysis)) {
+    // Old API: analysis is actually a dependencies array
+    bundled = analysis;
+    unbundledRuntime = [];
+    unbundledDev = [];
+    mainPackageBinaries = null; // Old API doesn't support this
+  } else {
+    // New API: analysis is an object with bundled/unbundled split
+    bundled = analysis.bundled || [];
+    unbundledRuntime = analysis.unbundledRuntime || [];
+    unbundledDev = analysis.unbundledDev || [];
   }
 
   const replacements = {
@@ -181,18 +196,26 @@ function generateSpecFile(npm_module, files, dependencies, release, template_nam
     COPYFILES: getCopyFiles(files),
     DOCFILES: getDocFiles(files),
     LEGACY_PEER_DEPS: getLegacyPeerDeps(use_legacy_peer_deps),
+    MAIN_PACKAGE_HAS_BINARIES: !!mainPackageBinaries,
+    PREP_BINARY_STRIP: mainPackageBinaries ? {files: mainPackageBinaries} : null,
   }
 
-  if (dependencies.length !== 0) {
-    dependencies = sortDependencies(dependencies);
+  if (bundled.length !== 0) {
+    const sortedBundled = sortDependencies(bundled.map(d => [d.name, d.version]));
     replacements['DEPENDENCIES'] = [];
-    replacements['PROVIDES'] = dependencies;
-    replacements['SOURCES'] = dependenciesToSources(npm_module.name, dependencies);
+    replacements['PROVIDES'] = sortedBundled;
+    replacements['SOURCES'] = dependenciesToSources(npm_module.name, sortedBundled);
   } else {
     replacements['DEPENDENCIES'] = dependenciesToRequires(npm_module['dependencies']);
     replacements['PROVIDES'] = [];
     replacements['SOURCES'] = ['Source0: ' + npmUrl(npm_module.name, '%{version}')];
   }
+
+  // Add unbundled dependencies as Requires/BuildRequires
+  // Runtime deps need both BuildRequires (for %check) and Requires (for runtime)
+  // Dev deps only need BuildRequires (for %check)
+  replacements['UNBUNDLED_REQUIRES'] = unbundledRuntime.map(d => d.name);
+  replacements['UNBUNDLED_BUILD_REQUIRES'] = [...unbundledRuntime, ...unbundledDev].map(d => d.name);
 
   const spec_file = fs.readFileSync(template_name, { encoding: 'utf8' });
   const template = Handlebars.compile(spec_file);

--- a/test/binary_detector.test.js
+++ b/test/binary_detector.test.js
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for binary_detector.js
+ *
+ * Tests detection of native binaries and WebAssembly modules
+ */
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const tmp = require('tmp');
+const binaryDetector = require('../lib/binary_detector');
+
+describe('binary_detector', function() {
+  let tmpDir;
+
+  beforeEach(function() {
+    // Create temp directory for test files
+    tmpDir = tmp.dirSync({ unsafeCleanup: true });
+  });
+
+  afterEach(function() {
+    // Clean up temp directory
+    if (tmpDir) {
+      tmpDir.removeCallback();
+    }
+  });
+
+  describe('hasBinaryExtension', function() {
+    it('should detect .node files', function() {
+      assert.strictEqual(binaryDetector.hasBinaryExtension('binding.node'), true);
+      assert.strictEqual(binaryDetector.hasBinaryExtension('/path/to/addon.node'), true);
+    });
+
+    it('should detect .wasm files', function() {
+      assert.strictEqual(binaryDetector.hasBinaryExtension('module.wasm'), true);
+      assert.strictEqual(binaryDetector.hasBinaryExtension('/path/to/code.wasm'), true);
+    });
+
+    it('should detect .so files', function() {
+      assert.strictEqual(binaryDetector.hasBinaryExtension('library.so'), true);
+      assert.strictEqual(binaryDetector.hasBinaryExtension('library.so.1'), true);
+      assert.strictEqual(binaryDetector.hasBinaryExtension('library.so.1.2.3'), true);
+    });
+
+    it('should detect .dylib files (macOS)', function() {
+      assert.strictEqual(binaryDetector.hasBinaryExtension('library.dylib'), true);
+    });
+
+    it('should detect .dll and .exe files (Windows)', function() {
+      assert.strictEqual(binaryDetector.hasBinaryExtension('library.dll'), true);
+      assert.strictEqual(binaryDetector.hasBinaryExtension('program.exe'), true);
+    });
+
+    it('should not detect JavaScript files', function() {
+      assert.strictEqual(binaryDetector.hasBinaryExtension('index.js'), false);
+      assert.strictEqual(binaryDetector.hasBinaryExtension('module.mjs'), false);
+    });
+
+    it('should not detect JSON files', function() {
+      assert.strictEqual(binaryDetector.hasBinaryExtension('package.json'), false);
+    });
+
+    it('should handle files with no extension', function() {
+      assert.strictEqual(binaryDetector.hasBinaryExtension('README'), false);
+      assert.strictEqual(binaryDetector.hasBinaryExtension('LICENSE'), false);
+    });
+
+    it('should be case-insensitive', function() {
+      assert.strictEqual(binaryDetector.hasBinaryExtension('MODULE.WASM'), true);
+      assert.strictEqual(binaryDetector.hasBinaryExtension('Binding.Node'), true);
+    });
+  });
+
+  describe('hasEmbeddedWasm', function() {
+    it('should detect base64-encoded Wasm magic bytes', function() {
+      const testFile = path.join(tmpDir.name, 'embedded.js');
+      const content = `
+        // This file contains embedded WebAssembly
+        const wasmBinary = "AGFzbQEAAAABhICAgAABYAAAYAF/AX8CjoCAgAABA2Vudg";
+      `;
+      fs.writeFileSync(testFile, content);
+
+      assert.strictEqual(binaryDetector.hasEmbeddedWasm(testFile), true);
+    });
+
+    it('should not detect files without Wasm magic bytes', function() {
+      const testFile = path.join(tmpDir.name, 'normal.js');
+      const content = `
+        const hello = "world";
+        console.log(hello);
+      `;
+      fs.writeFileSync(testFile, content);
+
+      assert.strictEqual(binaryDetector.hasEmbeddedWasm(testFile), false);
+    });
+
+    it('should not scan binary extension files', function() {
+      const testFile = path.join(tmpDir.name, 'binary.node');
+      fs.writeFileSync(testFile, 'AGFzbQEAAAA'); // Contains magic bytes
+
+      // Should return false because .node files are skipped
+      assert.strictEqual(binaryDetector.hasEmbeddedWasm(testFile), false);
+    });
+  });
+
+  describe('scanForBinaries', function() {
+    it('should find .node files in directory', function() {
+      const bindingPath = path.join(tmpDir.name, 'lib', 'binding');
+      fs.mkdirSync(bindingPath, { recursive: true });
+      fs.writeFileSync(path.join(bindingPath, 'addon.node'), 'fake binary');
+      fs.writeFileSync(path.join(tmpDir.name, 'index.js'), 'module.exports = {}');
+
+      const result = binaryDetector.scanForBinaries(tmpDir.name);
+
+      assert.strictEqual(result.hasBinaries, true);
+      assert.strictEqual(result.files.length, 1);
+      assert.strictEqual(result.files[0], path.join('lib', 'binding', 'addon.node'));
+    });
+
+    it('should find .wasm files in directory', function() {
+      fs.writeFileSync(path.join(tmpDir.name, 'module.wasm'), 'fake wasm');
+      fs.writeFileSync(path.join(tmpDir.name, 'index.js'), 'module.exports = {}');
+
+      const result = binaryDetector.scanForBinaries(tmpDir.name);
+
+      assert.strictEqual(result.hasBinaries, true);
+      assert.strictEqual(result.files.length, 1);
+      assert.strictEqual(result.files[0], 'module.wasm');
+    });
+
+    it('should find multiple binaries', function() {
+      fs.writeFileSync(path.join(tmpDir.name, 'binding.node'), 'fake binary');
+      fs.writeFileSync(path.join(tmpDir.name, 'module.wasm'), 'fake wasm');
+      fs.writeFileSync(path.join(tmpDir.name, 'library.so'), 'fake so');
+      fs.writeFileSync(path.join(tmpDir.name, 'index.js'), 'module.exports = {}');
+
+      const result = binaryDetector.scanForBinaries(tmpDir.name);
+
+      assert.strictEqual(result.hasBinaries, true);
+      assert.strictEqual(result.files.length, 3);
+      assert.ok(result.files.includes('binding.node'));
+      assert.ok(result.files.includes('module.wasm'));
+      assert.ok(result.files.includes('library.so'));
+    });
+
+    it('should return empty array for pure JavaScript package', function() {
+      fs.writeFileSync(path.join(tmpDir.name, 'index.js'), 'module.exports = {}');
+      fs.writeFileSync(path.join(tmpDir.name, 'package.json'), '{}');
+      fs.mkdirSync(path.join(tmpDir.name, 'lib'));
+      fs.writeFileSync(path.join(tmpDir.name, 'lib', 'util.js'), 'exports.foo = 1');
+
+      const result = binaryDetector.scanForBinaries(tmpDir.name);
+
+      assert.strictEqual(result.hasBinaries, false);
+      assert.strictEqual(result.files.length, 0);
+    });
+
+    it('should find embedded Wasm in JavaScript files', function() {
+      const jsFile = path.join(tmpDir.name, 'loader.js');
+      fs.writeFileSync(jsFile, 'const wasm = "AGFzbQEAAAA"');
+
+      const result = binaryDetector.scanForBinaries(tmpDir.name);
+
+      assert.strictEqual(result.hasBinaries, true);
+      assert.strictEqual(result.files.length, 1);
+      assert.strictEqual(result.files[0], 'loader.js');
+    });
+
+    it('should handle nested directory structures', function() {
+      const deepPath = path.join(tmpDir.name, 'a', 'b', 'c', 'd');
+      fs.mkdirSync(deepPath, { recursive: true });
+      fs.writeFileSync(path.join(deepPath, 'deep.node'), 'fake binary');
+      fs.writeFileSync(path.join(tmpDir.name, 'index.js'), 'module.exports = {}');
+
+      const result = binaryDetector.scanForBinaries(tmpDir.name);
+
+      assert.strictEqual(result.hasBinaries, true);
+      assert.strictEqual(result.files.length, 1);
+      assert.strictEqual(result.files[0], path.join('a', 'b', 'c', 'd', 'deep.node'));
+    });
+  });
+
+  describe('isBinaryByMimeType', function() {
+    // Note: These tests require the 'file' command to be available
+    // Skip if not available
+    before(function() {
+      try {
+        require('child_process').execSync('which file', { stdio: 'ignore' });
+      } catch (e) {
+        this.skip();
+      }
+    });
+
+    it('should detect text files as non-binary', function() {
+      const testFile = path.join(tmpDir.name, 'test.js');
+      fs.writeFileSync(testFile, 'console.log("hello");');
+
+      assert.strictEqual(binaryDetector.isBinaryByMimeType(testFile), false);
+    });
+
+    it('should detect JSON files as non-binary', function() {
+      const testFile = path.join(tmpDir.name, 'package.json');
+      fs.writeFileSync(testFile, '{"name": "test"}');
+
+      assert.strictEqual(binaryDetector.isBinaryByMimeType(testFile), false);
+    });
+
+    // Note: Creating actual ELF/Mach-O/PE binaries is complex
+    // In real testing, you'd test against actual npm packages with binaries
+  });
+});


### PR DESCRIPTION
Fedora packaging guidelines do not permit distributing pre-built
native binaries. If the primary source includes such files, they
should be deleted in the %prep stage. If dependencies include such
files, the module should be packaged on its own and not bundled.

This change introduces a command line option intended for use on
Fedora packages.