### PR TITLE
Replace npm-remote-ls dependency with simplified internal implementation

### DIFF
--- a/bin/npm2rpm.js
+++ b/bin/npm2rpm.js
@@ -7,13 +7,13 @@ const path = require('path');
 // NPM deps
 const request = require('request');
 const tar = require('tar');
-const npm_remote_ls = require('npm-remote-ls');
 const colors = require('colors');
 const npm2rpm = require('commander');
 const normalizeData = require('normalize-package-data');
 // Our own deps
 const {npmUrl, rsplit, getCacheFilename, getRpmPackageName} = require('../lib/npm_helpers.js');
 const specFileGenerator = require('../lib/spec_file_generator.js');
+const remoteLs = require('../lib/remote_ls.js');
 
 console.log('---- npm2rpm ----'.green.bold);
 console.log('-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-'.rainbow.bgWhite);
@@ -75,13 +75,11 @@ tar_stream.on('finish', () => {
   }
 
   if (npm2rpm.strategy === 'bundle') {
-    npm_remote_ls.config({
+    console.log(' - Fetching flattened list of production dependencies for '.bold + npm_module.name);
+    remoteLs.fetchDependencies(npm_module.name, npm_module.version, {
       development: false,
       optional: false
-    });
-
-    console.log(' - Fetching flattened list of production dependencies for '.bold + npm_module.name);
-    npm_remote_ls.ls(npm_module.name, npm_module.version, true, (deps) => {
+    }, (deps) => {
       // Dependencies come as name@version but sometimes as @name@version
       const dependencies = deps.map(dependency => rsplit(dependency, '@'));
 

--- a/lib/remote_ls.js
+++ b/lib/remote_ls.js
@@ -1,0 +1,144 @@
+/**
+ * Remote dependency listing
+ *
+ * Simplified version of npm-remote-ls that fetches a flattened list
+ * of production dependencies for a given package.
+ *
+ * Based on npm-remote-ls by npm, Inc.
+ */
+
+const semver = require('semver');
+const request = require('request');
+
+/**
+ * Fetch a flattened list of production dependencies
+ * @param {string} name - Package name
+ * @param {string} version - Package version (or 'latest')
+ * @param {Object} options - { development: boolean, optional: boolean, registry: string }
+ * @param {Function} callback - Called with array of 'name@version' strings
+ */
+function fetchDependencies(name, version, options, callback) {
+  // Handle optional parameters
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  const opts = Object.assign({
+    development: false,
+    optional: false,
+    registry: 'https://registry.npmjs.org'
+  }, options);
+
+  const flat = {};
+  const pending = new Set();
+  let processing = 0;
+
+  function done() {
+    processing--;
+    if (processing === 0 && pending.size === 0) {
+      callback(Object.keys(flat));
+    }
+  }
+
+  function loadPackage(pkgName, pkgVersion) {
+    const key = `${pkgName}@${pkgVersion}`;
+
+    // Skip if already processed or pending
+    if (flat[key] || pending.has(key)) {
+      return;
+    }
+
+    pending.add(key);
+    processing++;
+
+    // Escape scoped package names for registry URL
+    const escapedName = pkgName.replace(/\//g, '%2f');
+    const url = `${opts.registry.replace(/\/$/, '')}/${escapedName}`;
+
+    request.get(url, { json: true }, function (err, res, packageJson) {
+      pending.delete(key);
+
+      if (err || (res.statusCode < 200 || res.statusCode >= 400)) {
+        console.warn(`Warning: Could not load ${pkgName}@${pkgVersion}`);
+        done();
+        return;
+      }
+
+      try {
+        const resolvedVersion = guessVersion(pkgVersion, packageJson);
+        const versionData = packageJson.versions[resolvedVersion];
+
+        if (!versionData) {
+          console.warn(`Warning: Version ${resolvedVersion} not found for ${pkgName}`);
+          done();
+          return;
+        }
+
+        // Mark as processed with resolved version
+        const fullName = `${pkgName}@${resolvedVersion}`;
+        flat[fullName] = true;
+
+        // Collect dependencies
+        const deps = versionData.dependencies || {};
+
+        // Add optional dependencies if requested
+        if (opts.optional && versionData.optionalDependencies) {
+          Object.assign(deps, versionData.optionalDependencies);
+        }
+
+        // Add dev dependencies only for root package if requested
+        if (opts.development && pkgName === name && versionData.devDependencies) {
+          Object.assign(deps, versionData.devDependencies);
+        }
+
+        // Queue dependencies
+        Object.keys(deps).forEach(depName => {
+          loadPackage(depName, deps[depName]);
+        });
+
+      } catch (e) {
+        console.warn(`Warning: Error processing ${pkgName}@${pkgVersion}: ${e.message}`);
+      }
+
+      done();
+    });
+  }
+
+  // Start with the root package
+  loadPackage(name, version);
+}
+
+/**
+ * Resolve a version range to a specific version
+ */
+function guessVersion(versionString, packageJson) {
+  if (versionString === 'latest') {
+    versionString = '*';
+  }
+
+  const availableVersions = Object.keys(packageJson.versions);
+  let version = semver.maxSatisfying(availableVersions, versionString, true);
+
+  // Check for prerelease-only versions
+  if (!version && versionString === '*') {
+    const allPrerelease = availableVersions.every(av => {
+      const sv = new semver.SemVer(av, true);
+      return sv.prerelease && sv.prerelease.length > 0;
+    });
+
+    if (allPrerelease && packageJson['dist-tags'] && packageJson['dist-tags'].latest) {
+      version = packageJson['dist-tags'].latest;
+    }
+  }
+
+  if (!version) {
+    throw new Error(`Could not find a satisfactory version for string ${versionString}`);
+  }
+
+  return version;
+}
+
+module.exports = {
+  fetchDependencies
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "commander": "^2.9.0",
     "handlebars": "^4.0.11",
     "normalize-package-data": "^3.0.0",
-    "npm-remote-ls": "github:dLobatog/npm-remote-ls#optional-deps-fix",
     "request": "^2.81.0",
     "semver": "^5.4.1",
     "tar": "^4.0.0",


### PR DESCRIPTION
npm2rpm currently depends on a specific unpublished branch of npm-remote-ls (github:dLobatog/npm-remote-ls#optional-deps-fix) which makes it difficult to package npm2rpm itself for distribution.

This change replaces the external dependency with a simplified internal implementation in lib/remote_ls.js that provides only the functionality actually needed by npm2rpm:
- Fetching a flattened list of production dependencies
- Resolving version ranges using semver
- Handling scoped package names

The implementation uses only dependencies that npm2rpm already has (request and semver), avoiding the need to add additional dependencies like async, lodash, npm-package-arg, once, and registry-url that were required by the original npm-remote-ls.

This enables npm2rpm to be packaged for Fedora and other distributions without requiring access to unpublished npm packages or adding unnecessary dependencies.