### PR TITLE
Integrate npm-remote-ls source code to remove unpublished dependency

### DIFF
--- a/bin/npm2rpm.js
+++ b/bin/npm2rpm.js
@@ -7,13 +7,13 @@ const path = require('path');
 // NPM deps
 const request = require('request');
 const tar = require('tar');
-const npm_remote_ls = require('npm-remote-ls');
 const colors = require('colors');
 const npm2rpm = require('commander');
 const normalizeData = require('normalize-package-data');
 // Our own deps
 const {npmUrl, rsplit, getCacheFilename, getRpmPackageName} = require('../lib/npm_helpers.js');
 const specFileGenerator = require('../lib/spec_file_generator.js');
+const npmRemoteLs = require('../lib/npm-remote-ls.js');
 
 console.log('---- npm2rpm ----'.green.bold);
 console.log('-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-'.rainbow.bgWhite);
@@ -75,13 +75,13 @@ tar_stream.on('finish', () => {
   }
 
   if (npm2rpm.strategy === 'bundle') {
-    npm_remote_ls.config({
+    npmRemoteLs.config({
       development: false,
       optional: false
     });
 
     console.log(' - Fetching flattened list of production dependencies for '.bold + npm_module.name);
-    npm_remote_ls.ls(npm_module.name, npm_module.version, true, (deps) => {
+    npmRemoteLs.ls(npm_module.name, npm_module.version, true, (deps) => {
       // Dependencies come as name@version but sometimes as @name@version
       const dependencies = deps.map(dependency => rsplit(dependency, '@'));
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,10 @@
+var config = null
+
+module.exports = function (opts) {
+  if (!opts && config) {
+    return config
+  } else {
+    config = opts
+    return config
+  }
+}

--- a/lib/npm-remote-ls.js
+++ b/lib/npm-remote-ls.js
@@ -1,0 +1,24 @@
+exports.RemoteLS = require('./remote-ls')
+
+exports.config = function (opts) {
+  return require('./config')(opts)
+}
+
+exports.ls = function (name, version, flatten, cb) {
+  var ls = new exports.RemoteLS()
+
+  if (typeof version === 'function') {
+    cb = version
+    version = 'latest'
+  }
+
+  if (typeof flatten === 'function') {
+    cb = flatten
+    flatten = false
+  }
+
+  ls.ls(name, version, function () {
+    if (flatten) cb(Object.keys(ls.flat))
+    else cb(ls.tree)
+  })
+}

--- a/lib/remote-ls.js
+++ b/lib/remote-ls.js
@@ -1,0 +1,135 @@
+var _ = require('lodash')
+var async = require('async')
+var semver = require('semver')
+var request = require('request')
+var once = require('once')
+var npa = require('npm-package-arg')
+
+// perform a recursive walk of a remote
+// npm package and determine its dependency
+// tree.
+function RemoteLS (opts) {
+  var _this = this
+
+  _.extend(this, {
+    logger: console,
+    development: true, // include dev dependencies.
+    optional: true, // include optional dependencies.
+    peer: false, // include peer dependencies.
+    verbose: false,
+    registry: require('registry-url')(), // URL of registry to ls.
+    queue: async.queue(function (task, done) {
+      _this._loadPackageJson(task, done)
+    }, 8),
+    tree: {},
+    flat: {}
+  }, require('./config')(), opts)
+
+  this.queue.pause()
+}
+
+RemoteLS.prototype._loadPackageJson = function (task, done) {
+  var _this = this
+  var name = task.name
+
+  // account for scoped packages like @foo/bar
+  var couchPackageName = name && npa(name).escapedName
+
+  // wrap done so it's only called once
+  // if done throws in _walkDependencies, it will be called again in catch below
+  // we want to avoid "Callback was already called." from async
+  done = once(done)
+
+  request.get(this.registry.replace(/\/$/, '') + '/' + couchPackageName, {json: true}, function (err, res, obj) {
+    if (err || (res.statusCode < 200 || res.statusCode >= 400)) {
+      var message = res ? 'status = ' + res.statusCode : 'error = ' + err.message
+      _this.logger.log(
+        'could not load ' + name + '@' + task.version + ' ' + message
+      )
+      return done()
+    }
+
+    try {
+      if (_this.verbose) console.log('loading:', name + '@' + task.version)
+      _this._walkDependencies(task, obj, done)
+    } catch (e) {
+      _this.logger.log(e.message)
+      done()
+    }
+  })
+}
+
+RemoteLS.prototype._walkDependencies = function (task, packageJson, done) {
+  var _this = this
+  var version = this._guessVersion(task.version, packageJson)
+  var mandatoryDependencies = packageJson.versions[version].dependencies
+  // Remove the optionalDependencies from the list of optional + regular
+  // dependencies coming from the registry
+  if (packageJson.versions[version].optionalDependencies !== undefined) {
+    Object.keys(packageJson.versions[version].optionalDependencies).forEach(function (optionalDep) {
+      if (Object.keys(mandatoryDependencies).indexOf(optionalDep) > -1) {
+        delete mandatoryDependencies[optionalDep]
+      }
+    })
+  }
+
+  var dependencies = _.extend(
+    {},
+    mandatoryDependencies,
+    this.optional ? packageJson.versions[version].optionalDependencies : {},
+    this.peer ? packageJson.versions[version].peerDependencies : {},
+    // show development dependencies if we're at the root, and deevelopment flag is true.
+    (task.parent === this.tree && this.development) ? packageJson.versions[version].devDependencies : {}
+  )
+  var fullName = packageJson.name + '@' + version
+  var parent = task.parent[fullName] = {}
+
+  if (_this.flat[fullName]) return done()
+  else _this.flat[fullName] = true
+
+  Object.keys(dependencies).forEach(function (name) {
+    _this.queue.push({
+      name: name,
+      version: dependencies[name],
+      parent: parent
+    })
+  })
+
+  done()
+}
+
+RemoteLS.prototype._guessVersion = function (versionString, packageJson) {
+  if (versionString === 'latest') versionString = '*'
+
+  var availableVersions = Object.keys(packageJson.versions)
+  var version = semver.maxSatisfying(availableVersions, versionString, true)
+
+  // check for prerelease-only versions
+  if (!version && versionString === '*' && availableVersions.every(function (av) {
+    return new semver.SemVer(av, true).prerelease.length
+  })) {
+    // just use latest then
+    version = packageJson['dist-tags'] && packageJson['dist-tags'].latest
+  }
+
+  if (!version) throw Error('could not find a satisfactory version for string ' + versionString)
+  else return version
+}
+
+RemoteLS.prototype.ls = function (name, version, callback) {
+  var _this = this
+
+  this.queue.push({
+    name: name,
+    version: version,
+    parent: this.tree
+  })
+
+  this.queue.drain = function () {
+    callback(_this.tree)
+  }
+
+  this.queue.resume()
+}
+
+module.exports = RemoteLS

--- a/package.json
+++ b/package.json
@@ -28,11 +28,15 @@
     "url": "https://github.com/theforeman/npm2rpm/issues"
   },
   "dependencies": {
+    "async": "^2.0.0",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "handlebars": "^4.0.11",
+    "lodash": "^4.10.0",
     "normalize-package-data": "^3.0.0",
-    "npm-remote-ls": "github:dLobatog/npm-remote-ls#optional-deps-fix",
+    "npm-package-arg": "^4.2.0",
+    "once": "^1.3.3",
+    "registry-url": "^3.0.3",
     "request": "^2.81.0",
     "semver": "^5.4.1",
     "tar": "^4.0.0",


### PR DESCRIPTION
npm2rpm currently depends on a specific unpublished branch of npm-remote-ls (github:dLobatog/npm-remote-ls#optional-deps-fix) which makes it difficult to package npm2rpm itself for distribution.

This change integrates the npm-remote-ls source code directly into npm2rpm by copying three unmodified files from the npm-remote-ls repository:
- lib/config.js
- lib/remote-ls.js
- lib/index.js (renamed to lib/npm-remote-ls.js)

The required dependencies (async, lodash, npm-package-arg, once, registry-url) have been added to package.json. The npm-remote-ls code is used exactly as-is with no modifications, making it easy to update if needed in the future.

This enables npm2rpm to be packaged for Fedora and other distributions without requiring access to unpublished npm packages.